### PR TITLE
Include comment parameter while rating driver

### DIFF
--- a/src/main/java/org/example/RiderAppCLI.java
+++ b/src/main/java/org/example/RiderAppCLI.java
@@ -139,10 +139,12 @@ public class RiderAppCLI {
                     break;
 
                 case RATE_DRIVER:
-                    driverID = Long.parseLong(parts[1]);
-                    float rating = Float.parseFloat(parts[2]);
+                    rideID = Long.parseLong(parts[1]);
+                    driverID = Long.parseLong(parts[2]);
+                    float rating = Float.parseFloat(parts[3]);
+                    String comment = parts[4];
 
-                    float newRating = driverService.rateDriver(driverID, rating).getRating();
+                    float newRating = driverService.rateDriver(rideID, driverID, rating, comment).getRating();
                     log.info("CURRENT_RATING {} {}", driverID, newRating);
                     break;
 

--- a/src/main/java/org/example/controllers/DriverController.java
+++ b/src/main/java/org/example/controllers/DriverController.java
@@ -31,11 +31,13 @@ public class DriverController {
 
     @PostMapping("/rate")
     public ResponseEntity<DriverRatingDTO> rateDriver(
+            @RequestParam("rideID") long rideID,
             @RequestParam("driverID") long driverID,
-            @RequestParam("rating") float rating
+            @RequestParam("rating") float rating,
+            @RequestParam("comment") String comment
     ) {
-        log.info("Accessing endpoint: /driver/rate || PARAMS: driverID={}, rating={}", driverID, rating);
+        log.info("Accessing endpoint: /driver/rate || PARAMS: driverID={}, rating={}, comment={}", driverID, rating, comment);
 
-        return ResponseEntity.ok(driverService.rateDriver(driverID, rating));
+        return ResponseEntity.ok(driverService.rateDriver(rideID, driverID, rating, comment));
     }
 }

--- a/src/main/java/org/example/models/Ride.java
+++ b/src/main/java/org/example/models/Ride.java
@@ -22,6 +22,7 @@ public class Ride {
     @JoinColumn(name = "driver_id")
     private Driver driver;
 
+    private String comment;
     private String destination;
 
     @ElementCollection(fetch = FetchType.EAGER)

--- a/src/main/java/org/example/services/DriverService.java
+++ b/src/main/java/org/example/services/DriverService.java
@@ -4,5 +4,5 @@ import org.example.dto.DriverRatingDTO;
 
 public interface DriverService {
     long addDriver(String email, String phoneNumber, int x_coordinate, int y_coordinate);
-    DriverRatingDTO rateDriver(long driverID, float rating);
+    DriverRatingDTO rateDriver(long rideID, long driverID, float rating, String comment);
 }

--- a/src/main/java/org/example/services/impl/DriverServiceImpl.java
+++ b/src/main/java/org/example/services/impl/DriverServiceImpl.java
@@ -3,18 +3,27 @@ package org.example.services.impl;
 import lombok.extern.slf4j.Slf4j;
 import org.example.dto.DriverRatingDTO;
 import org.example.exceptions.InvalidDriverIDException;
+import org.example.exceptions.InvalidRideException;
 import org.example.models.Driver;
+import org.example.models.Ride;
 import org.example.repository.DriverRepository;
+import org.example.repository.RideRepository;
 import org.example.services.DriverService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.NoSuchElementException;
 
 
 @Slf4j
 @Service
 public class DriverServiceImpl implements DriverService {
+
     @Autowired
     private DriverRepository driverRepository;
+
+    @Autowired
+    private RideRepository rideRepository;
 
     @Override
     public long addDriver(String email, String phoneNumber, int x_coordinate, int y_coordinate) {
@@ -35,7 +44,7 @@ public class DriverServiceImpl implements DriverService {
     }
 
     @Override
-    public DriverRatingDTO rateDriver(long driverID, float rating) {
+    public DriverRatingDTO rateDriver(long rideID, long driverID, float rating, String comment) {
         log.info("Fetching details of driver '{}'...", driverID);
 
         Driver driver = driverRepository.findById(driverID)
@@ -46,6 +55,13 @@ public class DriverServiceImpl implements DriverService {
         driver.setRating(driver.getRatingSum() / driver.getRidesDone());
 
         driverRepository.save(driver);
+
+        Ride currentRide = rideRepository.findById(rideID)
+                        .orElseThrow(() -> new InvalidRideException("Invalid Ride ID - " + rideID, new NoSuchElementException("Ride does not exist in database")));
+
+        currentRide.setComment(comment);
+
+        rideRepository.save(currentRide);
 
         log.info("Updated the ratings of driver '{}'", driverID);
 

--- a/src/test/java/org/example/integration/CLITest.java
+++ b/src/test/java/org/example/integration/CLITest.java
@@ -127,7 +127,7 @@ class CLITest {
                 START_RIDE 2 1 Beach 4 5
                 STOP_RIDE 1 32
                 BILL 1
-                RATE_DRIVER 3 4.5
+                RATE_DRIVER 1 3 4.5 'Nice!'
                 """;
 
         String expectedOutput = """
@@ -410,7 +410,7 @@ class CLITest {
                 START_RIDE 2 1 Beach 4 5
                 STOP_RIDE 1 32
                 BILL 1
-                RATE_DRIVER 3 4.5
+                RATE_DRIVER 1 3 4.5 'Drove well!'
                 ADMIN_REMOVE_DRIVER 2
                 ADMIN_LIST_DRIVERS 2
                 """;

--- a/src/test/java/org/example/integration/MVCTest.java
+++ b/src/test/java/org/example/integration/MVCTest.java
@@ -575,8 +575,10 @@ public class MVCTest {
         String expectedDriverRatingJson = new ObjectMapper().writeValueAsString(expectedDriverRating);
 
         mockMvc.perform(post("/driver/rate")
+                        .param("rideID", "1")
                         .param("driverID", "3")
-                        .param("rating", "4.5"))
+                        .param("rating", "4.5")
+                        .param("comment", "Drove well!"))
                 .andExpect(status().isOk())
                 .andExpect(content().json(expectedDriverRatingJson));
 

--- a/src/test/java/org/example/unit/DriverServiceTest.java
+++ b/src/test/java/org/example/unit/DriverServiceTest.java
@@ -2,7 +2,9 @@ package org.example.unit;
 
 import org.example.dto.DriverRatingDTO;
 import org.example.models.Driver;
+import org.example.models.Ride;
 import org.example.repository.DriverRepository;
+import org.example.repository.RideRepository;
 import org.junit.jupiter.api.Test;
 import org.example.exceptions.InvalidDriverIDException;
 import org.example.services.DriverService;
@@ -23,6 +25,9 @@ import static org.mockito.Mockito.*;
 class DriverServiceTest {
     @MockitoBean
     private DriverRepository driverRepository;
+
+    @MockitoBean
+    private RideRepository rideRepository;
 
     @Autowired
     private DriverService driverService;
@@ -47,10 +52,14 @@ class DriverServiceTest {
         when(driverRepository.findById(driverID)).thenReturn(Optional.of(driver));
         when(driverRepository.save(any(Driver.class))).thenReturn(driver);
 
+        // Rider is null for the ride because it does not matter in this unit test
+        when(rideRepository.findById(1L)).thenReturn(Optional.of(new Ride(null, driver)));
+        when(rideRepository.save(any(Ride.class))).thenReturn(new Ride(null, driver));
+
         DriverRatingDTO expected = new DriverRatingDTO(driverID, 4.6f);
 
         float newRating = 4.6f;
-        DriverRatingDTO actual = driverService.rateDriver(driverID, newRating);
+        DriverRatingDTO actual = driverService.rateDriver(1, driverID, newRating, "Drives great");
 
         assertEquals(expected, actual, "Driver's rating don't match");
     }


### PR DESCRIPTION
Users can now add comments for their drivers when they access the ratings page.

Closes #9 